### PR TITLE
Fix GoFlow link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 - [PaPy](http://mcieslik-mctp.github.io/papy/) - "Parallel pipelines in Python"
 
 ### Go
-- [GoFlow](https://github.com/baffelli/pyperator) - Most well-known and mature Go-based FBP library
+- [GoFlow](https://github.com/trustmaster/goflow) - Most well-known and mature Go-based FBP library
 - [Cascades](https://github.com/cascades-fbp/cascades) - Language-agnostic Flow-based Programming (FBP) framework in Go
 - [FlowBase](http://flowbase.org/) - A Go-based FBP micro-framework, using native channels instead of reflection
 


### PR DESCRIPTION
The link to GoFlow linked to pyperator instead.